### PR TITLE
useeffect dependency warnings fix

### DIFF
--- a/src/app/cardview/[cardset_id]/edit/cards/page.tsx
+++ b/src/app/cardview/[cardset_id]/edit/cards/page.tsx
@@ -75,7 +75,7 @@ export default function AddCardsPage({
         }
 
         loadExistingCards();
-    }, [cardset_id]);
+    }, [cardset_id, supabase]);
 
     // ✅ Add a new card (only locally)
     const handleAddFlashcard = () => {

--- a/src/components/FlashcardRenderer.tsx
+++ b/src/components/FlashcardRenderer.tsx
@@ -68,7 +68,7 @@ export default function FlashcardRenderer({
             }
         }
         fetchData();
-    }, [cardsetId]);
+    }, [cardsetId, supabase]);
 
     const toggleCard = (id: number) => {
         setSelectedCardIds((prev) =>


### PR DESCRIPTION
React Hook useEffect has a missing dependency: 'supabase'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps